### PR TITLE
[Feat] Define .text-light style for html content

### DIFF
--- a/lib/base/custom_layers/local_json_layer/geojson_marker_modal.dart
+++ b/lib/base/custom_layers/local_json_layer/geojson_marker_modal.dart
@@ -117,6 +117,13 @@ class GeojsonMarkerModal extends StatelessWidget {
               children: [
                 Html(
                   data: element.popupContent!,
+                  style: {
+                    ".text-light": Style(
+                      color: const Color(0xFF747474),
+                      margin: Margins.only(top: 5, bottom: 5),
+                      fontSize: FontSize(13)
+                    ),
+                  },
                 ),
               ],
             ),
@@ -174,8 +181,11 @@ class GeojsonMarkerModal extends StatelessWidget {
         },
         child: Row(
           children: [
-            Icon(icon, size: 20,
-            color: Color(0xFF747474),),
+            Icon(
+              icon,
+              size: 20,
+              color: Color(0xFF747474),
+            ),
             const SizedBox(width: 8),
             Expanded(
               child: Text(

--- a/lib/base/custom_layers/local_json_layer/geojson_marker_modal.dart
+++ b/lib/base/custom_layers/local_json_layer/geojson_marker_modal.dart
@@ -119,7 +119,7 @@ class GeojsonMarkerModal extends StatelessWidget {
                   data: element.popupContent!,
                   style: {
                     ".text-light": Style(
-                      color: const Color(0xFF747474),
+                      color: const Color(0xFF666666),
                       margin: Margins.only(top: 5, bottom: 5),
                       fontSize: FontSize(13)
                     ),


### PR DESCRIPTION
Done: Adapt detail view of sights: description text [#953](https://github.com/stadtnavi/digitransit-ui/issues/953)

Define .text-light style for html content

![Simulator Screenshot - iPhone 16 Pro - 2025-03-17 at 23 30 33](https://github.com/user-attachments/assets/c680541a-af7d-4997-bdce-c1d2fc00b87f)

